### PR TITLE
Fix BodyJson variable type

### DIFF
--- a/apigateway/passthrough.go
+++ b/apigateway/passthrough.go
@@ -6,8 +6,8 @@ import (
 )
 
 type Request struct {
-	BodyJson string `json:"body-json"`
-	Params   Params `json:"params"`
+	BodyJson interface{} `json:"body-json"`
+	Params   Params      `json:"params"`
 }
 
 type Params struct {


### PR DESCRIPTION
`Contetnt-Type` が `application/x-www-form-urlencoded`の場合 body-json には"hoge=hige&..."とパラメータテキストが入る。
`Contetnt-Type` が `application/json`の場合 body-json には`"hoge":"hige", ...`とjsonが入るためinterfaceに変更


